### PR TITLE
Alter the visual structure of errors slightly

### DIFF
--- a/src/cljs/gc_api_browser/tabbed_request.cljs
+++ b/src/cljs/gc_api_browser/tabbed_request.cljs
@@ -53,13 +53,13 @@
                          (for [error (:errors validation-result)]
                            (dom/li
                              nil
+                             (:message error)
                              (dom/ul
                                nil
-                               (dom/li nil (str "message: " (:message error)))
                                (when-not (str/blank? (:data-path error))
-                                 (dom/li nil (str "data path: " (:data-path error))))
+                                 (dom/li nil (str "Data path: " (:data-path error))))
                                (when-not (str/blank? (:schema-path error))
-                                 (dom/li nil (str "schema path: " (:schema-path error)))))))))))))
+                                 (dom/li nil (str "Schema path: " (:schema-path error)))))))))))))
 
 (defn get? [request]
   (= "GET" (:method request)))


### PR DESCRIPTION
From
<img width="457" alt="screen shot 2015-11-04 at 09 38 08" src="https://cloud.githubusercontent.com/assets/237543/10934435/d1e6416a-82d7-11e5-99b9-15d927f1c5b2.png">
to
<img width="328" alt="screen shot 2015-11-04 at 09 37 50" src="https://cloud.githubusercontent.com/assets/237543/10934437/d4e34a0c-82d7-11e5-9c63-bd813bee1caa.png">
